### PR TITLE
feat: time-based features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 .DS_Store
 .DS_Store/
+.env

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ MarkupSafe==2.0.1
 Werkzeug==2.0.1
 pushnotif==0.0.1
 gunicorn==20.1.0
+python-dotenv==1.0.1

--- a/run.py
+++ b/run.py
@@ -120,7 +120,7 @@ def get_seed():
     month = month if len(month) == 2 else '0' + month
     day = day if len(day) == 2 else '0' + day
 
-    return year + month + day + str(round(today.second/15)) ## Testing
+    return year + month + day #+ str(round(today.second/15)) ## Testing
 
 
 def get_day_count():

--- a/run.py
+++ b/run.py
@@ -117,7 +117,7 @@ def get_seed():
     month = month if len(month) == 2 else '0' + month
     day = day if len(day) == 2 else '0' + day
 
-    return year + month + day
+    return year + month + day # + str(today.second) ## Testing
 
 
 def get_day_count():
@@ -147,9 +147,13 @@ def add_score(sc_int):
         print("Problem adding global scores")
         pass
 
+# Testing method
+# @app.route('/reset')
+# def test_session():
+#     session.clear()
+#     return redirect('/')
 
-def initialize_session(seed):
-    new_session = True
+def initialize_session(seed, new_session=True):
     if 'last_played' in session and session['last_played'] == seed:
         new_session = False
 
@@ -158,6 +162,9 @@ def initialize_session(seed):
         session['total_guesses'] = 0
         session['guess_history'] = []
         session['won_status'] = 0
+        session['start_time'] = int(datetime.now().timestamp())
+        session['time_played'] = -1
+        
 
     session['today_seed'] = seed
 
@@ -211,14 +218,21 @@ def index_seed(var=""):
     session['generate'] = True
     session['generate_key'] = var
 
-    print("Today seed: " + session['today_seed'])
+    print("Today seed: " + str(session['today_seed']))
     print("Answer: " + str(get_truth_value()))
     print("Total guesses: " + str(session['total_guesses']))
 
-    return render_template('index.html', answer_value=get_truth_ans(), total=session['total_guesses'],
+    return render_template('index.html',
+                           answer_value=get_truth_ans(),
+                           total=session['total_guesses'],
                            history=get_feedback_color(),
-                           labels=get_guesses(), won_status=session["won_status"], numble_day_count="#mynumble: " + var,
-                           global_remaining_time=next_word_time(), dark_mode=session['dark_mode'])
+                           labels=get_guesses(),
+                           won_status=session["won_status"],
+                           numble_day_count="#mynumble: " + var,
+                           global_remaining_time=next_word_time(),
+                           dark_mode=session['dark_mode'],
+                           time_played=session['time_played'],
+                           avg_time_played=session['avg_time_played'])
 
 
 @app.route('/')
@@ -230,17 +244,24 @@ def index():
 
     if 'scores' not in session:
         session['scores'] = defaultdict(int)
+        session['avg_time_played'] = -1
 
     session['generate'] = False
 
     print("Answer: " + str(get_truth_value()))
     print("Total guesses: " + str(session['total_guesses']))
 
-    return render_template('index.html', answer_value=get_truth_ans(), total=session['total_guesses'],
+    return render_template('index.html',
+                           answer_value=get_truth_ans(),
+                           total=session['total_guesses'],
                            history=get_feedback_color(),
-                           labels=get_guesses(), won_status=session["won_status"],
+                           labels=get_guesses(),
+                           won_status=session["won_status"],
                            numble_day_count="# " + str(get_day_count()),
-                           global_remaining_time=next_word_time(), dark_mode=session['dark_mode'])
+                           global_remaining_time=next_word_time(),
+                           dark_mode=session['dark_mode'],
+                           time_played=session['time_played'],
+                           avg_time_played=session['avg_time_played'])
 
 
 @app.route('/getScores', methods=['GET'])
@@ -302,18 +323,29 @@ def submit():
         label_ls = [i[2] for i in sorted(results[0], key=lambda a: a[0])]
 
         if results[1] != -1:
+            # Next guess
             session['guess_history'].append([i for i in sorted(results[0], key=lambda a: a[0])])
 
         if results[1] == 1:
+            # Won
             session['won_status'] = results[1]
+            session['time_played'] = int(datetime.now().timestamp()) - session['start_time']
 
-            # Stats
             if (not session['generate']) and ('scores' in session):
                 session['scores'][session['today_seed']] = session['total_guesses']
 
                 add_score(session['total_guesses'])
 
+                total_won = len([numble for numble in session['scores'] if numble[-1]!=0])
+
+                if session['avg_time_played'] == -1:
+                    session['avg_time_played'] = session['time_played']
+                else:
+                    session['avg_time_played'] = (session['avg_time_played']*total_won + session['time_played'])/(total_won+1)
+
+
         elif session['total_guesses'] >= 6:
+            # Loss
             session['won_status'] = -1
 
             if (not session['generate']) and ('scores' in session):
@@ -324,8 +356,14 @@ def submit():
 
         print("Total guesses: " + str(session['total_guesses']))
 
-    return jsonify({'value': results[1], 'ls': ls, 'labels': label_ls, 'next_word_time': next_word_time(),
-                    'session_total': session['total_guesses'], 'equation': get_truth_value()})
+    return jsonify({'value': results[1],
+                    'ls':ls,
+                    'labels': label_ls,
+                    'next_word_time': next_word_time(),
+                    'session_total': session['total_guesses'],
+                    'equation': get_truth_value(),
+                    'time_played': session['time_played'],
+                    'avg_time_played': session['avg_time_played']})
 
 
 if __name__ == '__main__':

--- a/static/css/timer.css
+++ b/static/css/timer.css
@@ -1,0 +1,25 @@
+.timer-container {
+    font-family: 'Inter', -apple-system, sans-serif;
+    /* background-color: #f8f9fa; */
+    padding: 1rem 1.5rem;
+    border-radius: 12px;
+    display: inline-flex;
+    align-items: center;
+    /* box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05); */
+    /* border: 1px solid #eee; */
+  }
+
+  .timer {
+    font-size: 1.5rem;
+    font-weight: 500;
+    color: #2d3748;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: -0.5px;
+  }
+
+  .timer-label {
+    font-size: 0.875rem;
+    color: #718096;
+    margin-left: 0.75rem;
+    font-weight: 400;
+  }

--- a/templates/index.html
+++ b/templates/index.html
@@ -218,7 +218,18 @@
                 
                 <div id = "youstats" class = "modal-body">
                     <div class = "container">
+                        <div style="display: none;" id = "todaystats">
+                            <div class="row">
+                                <div class="col-12 text-center">
+                                    <p><span id="your_timeplayed_minutes"></span></p>
+                                </div>
+                        
+                            </div>
+                            <hr>
+                        </div>
                         <div class = "row ml-4 mr-4">
+                            
+                            <p></p>
                             <div class = "col-12 text-center">
                                 <h5 ><b>DAILY STATISTICS</b></h5>
                             </div>
@@ -241,9 +252,14 @@
                             <div class = "col-4 text-center" style="margin-top:-10px">
                                 <small>Win %</small>
                             </div>
+                            <br><br>
+                            <div class = "col-12 text-center" style="margin-top:-10px">
+                                <small>Avg. Time : <b id ="avg_time_played_span">?</b></small>
+                            </div>
                             
                         </div>
                         <hr>
+
                         <div class = "col-12 text-center">
                             <p>Guess Distribution</p>
                         </div>
@@ -805,6 +821,80 @@
     //     this.classList.remove('btn-outline-secondary')
     // });
 
+    var showTodayStats = function(time_played, guesses, avg_time_played){
+        
+        document.getElementById('todaystats').style.display = 'block';
+
+        let time_str = "Today, it took you <b>";
+       
+        if (time_played < 60){
+            time_str += " just "+time_played + " seconds 🚀";
+                }
+        else{
+            if (time_played <120){
+                time_str += "1 minute 💯";
+            }
+            else{
+                time_str += Math.floor(time_played/60) + " minutes ⏳";
+            }
+        }
+        time_str += "</b><br>"
+
+        let diff_str = "";
+
+        console.log("HELLOAVG")
+        console.log(avg_time_played)
+        
+        if (avg_time_played != -1) {
+            let diff = ((time_played - avg_time_played) / avg_time_played) * 100;
+            let diff_str = "You were <b>"+diff.toFixed(0) + "%";
+
+            if (time_played >= avg_time_played) {
+                diff_str = diff_str + " slower 🐢</b> than your average";
+                
+            }
+            else{
+                diff_str = diff_str + " faster 🚀</b> than your average";
+            }
+            time_str = time_str + "" + diff_str;
+            
+        }
+
+        time_str += ""
+
+        
+        
+
+        // let guesses_str = "";
+
+        // if (guesses == 1){
+        //     guesses_str = guesses + " guess 🤯";
+        // }
+        // else if (guesses == 2){
+        //     guesses_str = guesses + " guesses 🤩";
+        // }
+        // else if (guesses == 3){
+        //     guesses_str = guesses + " guesses 😎";
+        // }
+        // else if (guesses == 4){
+        //     guesses_str = guesses + " guesses 😏";
+        // }
+        // else if (guesses == 5){
+        //     guesses_str = guesses + " guesses 😐";
+        // }
+        // else if (guesses == 6){
+        //     guesses_str = guesses + " guesses 😔";
+        // }
+
+                // console.log(response)
+        
+        document.getElementById('your_timeplayed_minutes').innerHTML = time_str;
+        console.log(time_str)
+        // $('#your_timeplayed_minutes').innerHTML = time_str;
+        // $('#your_timeplayed_guess_number').html(guesses_str)
+         
+    };
+
     var getYourStats = function(){
         $.ajax({
             url: '/getScores',
@@ -862,6 +952,17 @@
     
     var cur_count = 0;
     var total_guesses =  {{ total }};
+    var time_played = {{ time_played }};
+    var avg_time_played = {{ avg_time_played }};
+
+    if (avg_time_played != -1){
+        let avg_mins = Math.floor(avg_time_played/60);
+        let avg_secs = Math.round(avg_time_played%60);
+
+        let avg_time_str = avg_mins+"m "+avg_secs+"s";
+        document.getElementById('avg_time_played_span').innerHTML = avg_time_str;
+    }
+
     var numble_day_count = "{{numble_day_count}}";
 
     var guess_history = {{ history }};
@@ -1115,6 +1216,7 @@
         }
     if (game_end_status==1){
         winFunction(global_remaining_time);
+        showTodayStats(time_played,total_guesses, -1);
     }
     else if (game_end_status==-1){
         loseFunction(global_remaining_time);
@@ -1208,6 +1310,8 @@ function checkKey(e) {
 					success: function(data) {
 
                         total_guesses = data['session_total']
+                        time_played = data['time_played']
+                        avg_time_played = data['avg_time_played']
                         
                         // console.log(data)
                         if (data['value']==-1){
@@ -1286,7 +1390,13 @@ function checkKey(e) {
                                 // console.log(data["next_word_time"])
                                 // nextWordTime();
 
-                                
+                                // GA event for winning the game
+                                console.log(time_played)
+                                gtag('event', 'game_complete', {
+                                    'value': 0,
+                                    'total_guesses': total_guesses,
+                                    'time_played': time_played
+                                });
 
                                 loseFunction("<br>in <b>"+data['next_word_time']+"</b><br>Today's equation was: <br><b>"+data['equation']+"</b>");
                                 getYourStats();
@@ -1348,12 +1458,20 @@ function checkKey(e) {
 
 
 
-                            // document.getElementById('win').classList.add('badge','badge-danger');
+                            // GA event for winning the game
+                            console.log(time_played)
+                            console.log("WON GAME EVENT")
+                            gtag('event', 'game_complete', {
+                                'value': 1,
+                                'total_guesses': total_guesses,
+                                'time_played': time_played
+                            });
 
-
-                            // winFunction(data['next_word_time']);
                             winFunction("<br>in <b>"+data['next_word_time']+"</b>");
+                            showTodayStats(time_played,total_guesses,avg_time_played);
                             getYourStats();
+
+
                             // $('#scoreModal').modal('show');
                             setTimeout(function(){
                                     $('#scoreModal').modal('show');

--- a/templates/index.html
+++ b/templates/index.html
@@ -72,6 +72,8 @@
         {% else %}
         <link rel="stylesheet" href="{{ url_for('static', filename='css/light.css') }}">
         {% endif %}
+
+        <!-- <link rel="stylesheet" href="{{ url_for('static', filename='css/timer.css') }}"> -->
         
     </head>
     <body>
@@ -254,7 +256,7 @@
                             </div>
                             <br><br>
                             <div class = "col-12 text-center" style="margin-top:-10px">
-                                <small>Avg. Time : <b id ="avg_time_played_span">?</b></small>
+                                <small>Avg. Win Time : </small><b id ="avg_time_played_span">?</b>
                             </div>
                             
                         </div>
@@ -445,10 +447,16 @@
             
             <hr style="width: 15rem;margin-top:0;margin-bottom:5px;">
         </div>
+
         <div class = "container d-flex justify-content-center ">
             <button type="button" id="numbleAlive" class="btn btn-sm btn-outline-secondary">Keep Numble alive!</button>
 
         </div>
+
+        <!-- <div class="container d-flex justify-content-center timer-container">
+            <div class="timer" id="timer">00:00:00</div>
+            <div class="timer-label">elapsed</div>
+          </div> -->
 
         <div class = "container d-flex justify-content-center ">
     
@@ -643,8 +651,32 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
 
-
 <script>
+    
+//     const startTime = {{start_time}}*1000;
+//     // console.log(startTime)
+
+//     // console.log({{start_time}})
+    
+// function updateTimer() {
+//   const elapsedTime = Math.floor((Date.now() - startTime) / 1000); // Convert to seconds
+  
+//   // Calculate hours, minutes, seconds
+//   const hours = Math.floor(elapsedTime / 3600);
+//   const minutes = Math.floor((elapsedTime % 3600) / 60);
+//   const seconds = elapsedTime % 60;
+
+//   // Format with leading zeros
+//   const format = (num) => String(num).padStart(2, '0');
+  
+//   // Update the display
+//   document.getElementById('timer').textContent = 
+//     `${format(hours)}:${format(minutes)}:${format(seconds)}`;
+// }
+
+// // Update every second
+// setInterval(updateTimer, 1000);
+// updateTimer(); // Initial 
 
     // PRACTICE AREA
 
@@ -842,19 +874,23 @@
 
         let diff_str = "";
 
-        console.log("HELLOAVG")
-        console.log(avg_time_played)
-        
         if (avg_time_played != -1) {
-            let diff = ((time_played - avg_time_played) / avg_time_played) * 100;
+            console.log(time_played)
+            console.log(avg_time_played)
+            
+            let diff = Math.abs(((time_played.toFixed(0) - avg_time_played.toFixed(0)) / avg_time_played.toFixed(0)) * 100);
+            
             let diff_str = "You were <b>"+diff.toFixed(0) + "%";
 
-            if (time_played >= avg_time_played) {
+            if (time_played > avg_time_played) {
                 diff_str = diff_str + " slower 🐢</b> than your average";
                 
             }
+            else if (time_played == avg_time_played){
+                diff_str = diff_str + " on par 🎯</b> with your average";
+            }
             else{
-                diff_str = diff_str + " faster 🚀</b> than your average";
+                diff_str = diff_str + " faster 💨</b> than your average";
             }
             time_str = time_str + "" + diff_str;
             
@@ -953,6 +989,8 @@
     var cur_count = 0;
     var total_guesses =  {{ total }};
     var time_played = {{ time_played }};
+
+    
     var avg_time_played = {{ avg_time_played }};
 
     if (avg_time_played != -1){
@@ -1312,6 +1350,13 @@ function checkKey(e) {
                         total_guesses = data['session_total']
                         time_played = data['time_played']
                         avg_time_played = data['avg_time_played']
+
+                        gtag('event', 'game_guess', {
+                            'total_guesses': total_guesses,
+                            'time_played': time_played
+                        });
+
+                        console.log(time_played)
                         
                         // console.log(data)
                         if (data['value']==-1){
@@ -1391,11 +1436,12 @@ function checkKey(e) {
                                 // nextWordTime();
 
                                 // GA event for winning the game
-                                console.log(time_played)
+                                // console.log(time_played)
                                 gtag('event', 'game_complete', {
-                                    'value': 0,
+                                    'win_status': 0,
                                     'total_guesses': total_guesses,
-                                    'time_played': time_played
+                                    'time_played': time_played,
+                                    'avg_time_played': avg_time_played
                                 });
 
                                 loseFunction("<br>in <b>"+data['next_word_time']+"</b><br>Today's equation was: <br><b>"+data['equation']+"</b>");
@@ -1459,12 +1505,12 @@ function checkKey(e) {
 
 
                             // GA event for winning the game
-                            console.log(time_played)
                             console.log("WON GAME EVENT")
                             gtag('event', 'game_complete', {
-                                'value': 1,
+                                'win_status': 1,
                                 'total_guesses': total_guesses,
-                                'time_played': time_played
+                                'time_played': time_played,
+                                'avg_time_played': avg_time_played
                             });
 
                             winFunction("<br>in <b>"+data['next_word_time']+"</b>");


### PR DESCRIPTION
This pull request introduces several new features and improvements to the `run.py` file, as well as updates to the HTML and CSS files to support these features. The main changes include adding session timing and average time played tracking, adding a reset endpoint, and updating the user interface to display these new statistics.

### Session Timing and Average Time Played Tracking:
* `run.py`: Added session start time and time played tracking in the `initialize_session` and `submit` functions. Updated the session data to include `start_time`, `time_played`, and `avg_time_played`.
* `templates/index.html`: Added JavaScript functions to display the time played and average time played in the user interface.

### Reset Endpoint:
* `run.py`: Added a new endpoint `/reset` to clear the session data when the environment is set to local.

### User Interface Updates:
* `templates/index.html`: Updated the modal to display daily statistics, including time played and average time played.
* `static/css/timer.css`: Added styles for the timer display (currently commented out - to be added in the future).

### Miscellaneous Changes:
* `run.py`: Added the `dotenv` library and loaded environment variables at the start of the script.
* `run.py`: Minor code clean-up and comments added for testing purposes.

These changes improve the user experience by providing more detailed statistics and allowing for easier testing and resetting of sessions.

Also added gtag tracking for events including,
- `game_completed` - for win and loss
- `game_guess` - for every guess