### PR TITLE
feat: change avg time calculation

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -878,19 +878,21 @@
             console.log(time_played)
             console.log(avg_time_played)
             
-            let diff = Math.abs(((time_played.toFixed(0) - avg_time_played.toFixed(0)) / avg_time_played.toFixed(0)) * 100);
-            
-            let diff_str = "You were <b>"+diff.toFixed(0) + "%";
 
+            
+            let diff_str = "You were <b>";
             if (time_played > avg_time_played) {
-                diff_str = diff_str + " slower 🐢</b> than your average";
+                let diff = time_played / avg_time_played;
+                diff_str = diff_str + diff.toFixed(1) +" times slower 🐢</b> than your previous average.";
                 
             }
             else if (time_played == avg_time_played){
+                
                 diff_str = diff_str + " on par 🎯</b> with your average";
             }
             else{
-                diff_str = diff_str + " faster 💨</b> than your average";
+                let diff = avg_time_played / time_played;
+                diff_str = diff_str + diff.toFixed(1) +" times faster 💨</b> than your previous average.";
             }
             time_str = time_str + "" + diff_str;
             

--- a/templates/index.html
+++ b/templates/index.html
@@ -1434,6 +1434,9 @@ function checkKey(e) {
 
                                 // GA event for winning the game
                                 // console.log(time_played)
+                                gtag('event','game_complete',{
+                                    'value':0
+                                })
                                 gtag('event', 'game_lost_event', {
                                     'value': total_guesses,
                                     'total_guesses': total_guesses,
@@ -1502,6 +1505,9 @@ function checkKey(e) {
 
 
                             // GA event for winning the game
+                            gtag('event','game_complete',{
+                                    'value':1
+                                })
                             gtag('event', 'game_won_event', {
                                 'value': total_guesses,
                                 'total_guesses': total_guesses,

--- a/templates/index.html
+++ b/templates/index.html
@@ -872,36 +872,31 @@
         }
         time_str += "</b><br>"
 
-        let diff_str = "";
+
+        let am = Math.floor(avg_time_played/60);
+        let as = Math.round(avg_time_played%60);
+
+        let avg_t_str = am+"m "+as+"s";
 
         if (avg_time_played != -1) {
-            console.log(time_played)
-            console.log(avg_time_played)
-            
-
             
             let diff_str = "You were <b>";
-            if (time_played > avg_time_played) {
-                let diff = time_played / avg_time_played;
-                diff_str = diff_str + diff.toFixed(1) +" times slower 🐢</b> than your previous average.";
+
+            if (time_played.toFixed(0) == avg_time_played.toFixed(0)){
                 
+                diff_str+= + " on par 🎯</b> with your average";
             }
-            else if (time_played == avg_time_played){
+            else if (time_played > avg_time_played) {
+                diff_str+= ((time_played / avg_time_played)-1).toFixed(1) +"x slower 🐢</b> than your average of "+avg_t_str;
                 
-                diff_str = diff_str + " on par 🎯</b> with your average";
             }
             else{
-                let diff = avg_time_played / time_played;
-                diff_str = diff_str + diff.toFixed(1) +" times faster 💨</b> than your previous average.";
+                diff_str+= ((avg_time_played / time_played)-1).toFixed(1) +"x faster 💨</b> than your average of "+avg_t_str;
             }
-            time_str = time_str + "" + diff_str;
+
+            time_str+= "" + diff_str;
             
         }
-
-        time_str += ""
-
-        
-        
 
         // let guesses_str = "";
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -1434,8 +1434,8 @@ function checkKey(e) {
 
                                 // GA event for winning the game
                                 // console.log(time_played)
-                                gtag('event', 'game_complete', {
-                                    'win_status': 0,
+                                gtag('event', 'game_lost_event', {
+                                    'value': total_guesses,
                                     'total_guesses': total_guesses,
                                     'time_played': time_played,
                                     'avg_time_played': avg_time_played
@@ -1502,9 +1502,8 @@ function checkKey(e) {
 
 
                             // GA event for winning the game
-                            console.log("WON GAME EVENT")
-                            gtag('event', 'game_complete', {
-                                'win_status': 1,
+                            gtag('event', 'game_won_event', {
+                                'value': total_guesses,
                                 'total_guesses': total_guesses,
                                 'time_played': time_played,
                                 'avg_time_played': avg_time_played


### PR DESCRIPTION

This pull request includes changes to the `templates/index.html` file to improve the user experience by providing more detailed feedback on game performance and updating Google Analytics event tracking.

Improvements to user feedback:

* [`templates/index.html`](diffhunk://#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2L881-R895): Updated the calculation of the time difference to use a ratio instead of a percentage, providing a more intuitive comparison between the current and average play times.
Updates to Google Analytics event tracking:

* Changed the event name for losing a game from `game_complete` to `game_lost_event` and included the `value` parameter.
* Changed the event name for winning a game from `game_complete` to `game_won_event` and included the `value` parameter.