### PR TITLE
feat: add total player count

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -537,7 +537,9 @@
                     <button class="btn btn-lg">☽</button>
                 </a>
             </h1>
-            <small style="font-size:0.8rem;" id = "notif">{{numble_day_count}}</small>
+            <small style="font-size:0.8rem;" id = "notif">{{numble_day_count}}</small> 
+
+        <small style="font-size:0.8rem;">| Numblers Today: <span class="badge badge-secondary">2000{{ numble_player_count }}</span></small>
             <!-- <small style="font-size:1rem;" id = "today_games"><sup>Won </sup><btn class="btn btn-sm btn-success">25</btn></small> -->
             <!-- <small style="font-size:1rem;" id = "today_games"><btn class="btn btn-sm btn-danger">2</btn><sup> Lost</sup></small> -->
             


### PR DESCRIPTION
This pull request includes several changes to the `run.py` file and one change to the `index.html` template. The main purpose of these changes is to add tracking and display of the number of players for the current day.

Key changes include:

### Enhancements to player tracking:
* Added a new Redis key to store the number of players for the current day in the `initialise_redis_seed` function.
* Incremented the daily player count in the `initialize_session` function if the session seed changes.

### Display updates:
* Added the number of players for the current day to the context of the `index_seed` and `index` functions, and handled potential exceptions when retrieving this value from Redis. [[1]](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0R383-R395) [[2]](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0R432-R446)
* Displayed the number of players for the current day on the index page in the `index.html` template.

### Minor adjustments:
* Fixed a minor formatting issue in the `get_seed` function.
* Removed an unnecessary blank line in the `get_redis_stats` function.