### PR TITLE
hotfix: redis today seed initialisation race condition fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 .DS_Store
 .DS_Store/
 .env
+*.ipynb

--- a/run.py
+++ b/run.py
@@ -124,6 +124,12 @@ def set_redis_stats(today_seed,
                 else:
                     pipe.incr(f'{NUMBLE_ENV_VAR}_today_losses')
                     pipe.incr(f'{NUMBLE_ENV_VAR}_today_time_played_loss', time_played)
+
+            else:
+                # Generate latest seed
+                check_seed = get_seed()
+                if check_seed != today_seed_redis:
+                    initialise_redis_seed(check_seed)
                     
             pipe.execute()
     except Exception as e:

--- a/run.py
+++ b/run.py
@@ -112,7 +112,24 @@ def set_redis_stats(today_seed,
                 pipe.incr(f'{NUMBLE_ENV_VAR}_total_losses')
                 pipe.incr(f'{NUMBLE_ENV_VAR}_total_time_played_loss', time_played)
 
-            if today_seed_redis == today_seed:
+            # Check if currently played game seed is same as redis seed
+            update_today_stats = (today_seed_redis == today_seed)
+
+            if not update_today_stats:
+                check_seed = get_seed()
+
+                # If not, check if redis seed is outdated
+                if check_seed != today_seed_redis:
+
+                    # If outdated, initialise redis seed
+                    initialise_redis_seed(check_seed)
+
+                    # Check if currently played game seed is same as newly initialised seed
+
+                    # If yes, update today stats, else the game seed is outdated
+                    update_today_stats = (check_seed == today_seed)
+
+            if update_today_stats:
                 pipe.incr(f'{NUMBLE_ENV_VAR}_today_games')
                 if game_status == 1:
                     pipe.incr(f'{NUMBLE_ENV_VAR}_today_wins')
@@ -125,11 +142,6 @@ def set_redis_stats(today_seed,
                     pipe.incr(f'{NUMBLE_ENV_VAR}_today_losses')
                     pipe.incr(f'{NUMBLE_ENV_VAR}_today_time_played_loss', time_played)
 
-            else:
-                # Generate latest seed
-                check_seed = get_seed()
-                if check_seed != today_seed_redis:
-                    initialise_redis_seed(check_seed)
                     
             pipe.execute()
     except Exception as e:


### PR DESCRIPTION
This pull request includes changes to the `set_redis_stats` function in the `run.py` file to improve the handling of game seed updates and ensure accurate statistics tracking.

Improvements to game seed handling:

* [`run.py`](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0L115-R132): Added logic to check if the currently played game seed matches the redis seed, and if not, verify if the redis seed is outdated. If the redis seed is outdated, it initializes the redis seed with the correct value and updates today's stats accordingly.

Codebase simplification:

* [`run.py`](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0R145): Removed unnecessary whitespace to improve code readability.