### PR TITLE
feature: add ezoic ad integration

### DIFF
--- a/run.py
+++ b/run.py
@@ -405,6 +405,9 @@ def index_seed(var=""):
                            avg_time_played=-1,
                            start_time=session['start_time'])
 
+@app.route('/ads.txt')
+def ads_txt():
+    return redirect('https://srv.adstxtmanager.com/19390/thenumble.app')
 
 @app.route('/')
 def index():

--- a/run.py
+++ b/run.py
@@ -323,6 +323,10 @@ def test_session():
     else:
         print("Not allowed")
         return redirect('/')
+    
+@app.route('/ads.txt')
+def ads_txt():
+    return redirect('https://srv.adstxtmanager.com/19390/thenumble.app')
 
 def initialize_session(seed, new_session=True):
     if 'last_played' in session and session['last_played'] == seed:
@@ -404,10 +408,6 @@ def index_seed(var=""):
                            time_played=session['time_played'],
                            avg_time_played=-1,
                            start_time=session['start_time'])
-
-@app.route('/ads.txt')
-def ads_txt():
-    return redirect('https://srv.adstxtmanager.com/19390/thenumble.app')
 
 @app.route('/')
 def index():

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,15 @@
 <!--[if gt IE 8]>      <html class="no-js"> <!--<![endif]-->
 <html>
     <head>
+        <script src="https://cmp.gatekeeperconsent.com/min.js" data-cfasync="false"></script>
+        <script src="https://the.gatekeeperconsent.com/cmp.min.js" data-cfasync="false"></script>
+
+        <script async src="//www.ezojs.com/ezoic/sa.min.js"></script>
+        <script>
+            window.ezstandalone = window.ezstandalone || {};
+            ezstandalone.cmd = ezstandalone.cmd || [];
+        </script>
+
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
 


### PR DESCRIPTION
This pull request introduces changes aimed at improving ad management and compliance for the site. The most significant updates include adding a redirect for the `ads.txt` file to support ad verification and integrating scripts for consent management and ad services in the main HTML template.

**Ad management and compliance:**

* Added a new route `/ads.txt` in `run.py` that redirects to an external ads.txt manager, ensuring proper ad verification for the site.

**Third-party script integration:**

* Included Gatekeeper Consent Management Platform scripts in `templates/index.html` to handle user consent for cookies and tracking.
* Added Ezoic ad service script and initialization code to `templates/index.html` to enable ad serving and optimization features.