### PR TITLE
fix: time calculation

### DIFF
--- a/client_app/js/app.js
+++ b/client_app/js/app.js
@@ -202,6 +202,7 @@ function handleKeyPress(e) {
 
     if (keyCodes.includes(e.key)) {
         if (curCount < 7) {
+            startTimer();
             const boxIndex = (session.totalGuesses * 9) + curCount;
             $('.box').eq(boxIndex).text(e.key);
             curCount++;

--- a/client_app/js/storage.js
+++ b/client_app/js/storage.js
@@ -35,15 +35,15 @@ function initializeSession(seed, isCustomSeed = false) {
         localStorage.setItem(STORAGE_KEYS.TOTAL_GUESSES, '0');
         localStorage.setItem(STORAGE_KEYS.GUESS_HISTORY, JSON.stringify([]));
         localStorage.setItem(STORAGE_KEYS.WON_STATUS, '0');
-        localStorage.setItem(STORAGE_KEYS.START_TIME, String(Math.floor(Date.now() / 1000)));
+        localStorage.setItem(STORAGE_KEYS.START_TIME, '0');
         localStorage.setItem(STORAGE_KEYS.TIME_PLAYED, '-1');
         localStorage.setItem(STORAGE_KEYS.CURRENT_INPUT, '');
         localStorage.setItem(STORAGE_KEYS.CURRENT_COUNT, '0');
     } else {
         // Same day - preserve start time if it exists, otherwise set it
         const existingStartTime = localStorage.getItem(STORAGE_KEYS.START_TIME);
-        if (!existingStartTime || existingStartTime === '0') {
-            localStorage.setItem(STORAGE_KEYS.START_TIME, String(Math.floor(Date.now() / 1000)));
+        if (!existingStartTime) {
+            localStorage.setItem(STORAGE_KEYS.START_TIME, '0');
         }
     }
 
@@ -104,6 +104,16 @@ function updateSession(updates) {
     }
     if (updates.currentCount !== undefined) {
         localStorage.setItem(STORAGE_KEYS.CURRENT_COUNT, String(updates.currentCount));
+    }
+}
+
+/**
+ * Start the timer if it hasn't been started yet
+ */
+function startTimer() {
+    const existingStartTime = localStorage.getItem(STORAGE_KEYS.START_TIME);
+    if (!existingStartTime || existingStartTime === '0') {
+        localStorage.setItem(STORAGE_KEYS.START_TIME, String(Math.floor(Date.now() / 1000)));
     }
 }
 


### PR DESCRIPTION
This pull request updates the session timer logic to ensure the game timer only starts when the user begins inputting a guess, rather than at session initialization. The main changes involve deferring the timer start and centralizing timer control.

Timer logic improvements:

* Added a new `startTimer()` function in `storage.js` to set `START_TIME` only if it hasn't been set yet.
* Updated `handleKeyPress` in `app.js` to call `startTimer()` when the user enters their first guess, ensuring the timer starts with the first input.

Session initialization changes:

* Modified `initializeSession` in `storage.js` to set `START_TIME` to `'0'` at the start of a new session, and to avoid starting the timer immediately. Also updated logic for existing sessions to only set `START_TIME` to `'0'` if it is missing, not if it is already `'0'`.